### PR TITLE
Use site.RegularPages and site.mainSections

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,7 +9,7 @@
         {{ end }}
 
         <div class="posts-list">
-          {{ $pag := .Paginate (where .Data.Pages "Type" "post") }}
+          {{ $pag := .Paginate (where site.RegularPages "Type" "in" site.Params.mainSections) }}
           {{ range $pag.Pages }}
             <article class="post-preview">
               <a href="{{ .Permalink }}">


### PR DESCRIPTION
You may refer to [Hugo's docs about `mainSections`](https://gohugo.io/functions/where/#mainsections) for listing Page Resources in home page.

> To list the most relevant pages on the front page or similar, you should use the `site.Params.mainSections` list instead of comparing section names to hard-coded values like `"posts"` or `"post"`.
>
> ```go
> {{ $pages := where site.RegularPages "Type" "in" site.Params.mainSections }}
> ```